### PR TITLE
feat: 계획블록 생성

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "body-parser": "^1.20.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
+    "dayjs": "^1.11.7",
     "dotenv": "^16.0.0",
     "express": "^4.17.3",
     "express-validator": "^6.14.0",

--- a/src/controllers/PlanController.ts
+++ b/src/controllers/PlanController.ts
@@ -10,6 +10,9 @@ import {
   QueryParams,
   UseBefore,
   UseAfter,
+  BodyParam,
+  Body,
+  Post,
 } from 'routing-controllers';
 import errorValidator from '../middleware/errorValidator';
 import { IsString } from 'class-validator';
@@ -19,6 +22,7 @@ import { Request, Response } from 'express';
 import statusCode from '../modules/statusCode';
 import message from '../modules/responseMessage';
 import { success, fail } from '../modules/util';
+import dayjs from 'dayjs';
 
 class GetTypeAndDateQuery {
   @IsString()
@@ -52,6 +56,46 @@ export class DailyPlanController {
       return res
         .status(statusCode.OK)
         .send(success(statusCode.OK, message.READ_PLAN_SUCCESS, data));
+    } catch (error) {
+      console.log(error);
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR),
+        );
+    }
+  }
+
+  @HttpCode(200)
+  @Post('/:userId')
+  @OpenAPI({
+    summary: '계획 블록 조회',
+    description: '일간 계획, 우회할 계획, 루틴로드 조회',
+    statusCode: '200',
+  })
+  public async createPlan(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Param('userId') userId: string,
+    @BodyParam('planName') planName: string,
+    @BodyParam('date') date: string,
+    @BodyParam('type') type: string,
+  ) {
+    if (!planName || !date || !type) {
+      return res
+        .status(statusCode.BAD_REQUEST)
+        .send(fail(statusCode.BAD_REQUEST, message.BAD_REQUEST));
+    }
+    try {
+      const data = await this.dailyPlanService.createPlan(
+        +userId,
+        planName,
+        dayjs(date, 'YYYY-MM-DD').toDate(),
+        type,
+      );
+      return res
+        .status(statusCode.CREATED)
+        .send(success(statusCode.CREATED, message.CREATE_PLAN_SUCCESS, data));
     } catch (error) {
       console.log(error);
       return res

--- a/src/entities/PlanOrder.ts
+++ b/src/entities/PlanOrder.ts
@@ -15,7 +15,7 @@ export class PlanOrder {
   type?: string;
 
   @Column({ name: 'plan_date', nullable: false })
-  planDate?: string;
+  planDate?: Date;
 
   @Column('int', { name: 'plan_list', array: true })
   planList?: number[];

--- a/src/middleware/errorValidator.ts
+++ b/src/middleware/errorValidator.ts
@@ -5,7 +5,11 @@ import statusCode from '../modules/statusCode';
 import { fail } from '../modules/util';
 const { validationResult } = require('express-validator');
 
-const errorValidator = (req: Request, res: Response, next: NextFunction) => {
+export const errorValidator = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
     return res
@@ -15,15 +19,20 @@ const errorValidator = (req: Request, res: Response, next: NextFunction) => {
   next();
 };
 
-const getPlanValidation = [
+export const getPlanValidation = [
   query('type').notEmpty().isIn(['daily', 'routine', 'reschedule']),
   query('planDate').notEmpty(),
 ];
 
-const updatePlanValidation = [
-  check('planName').if(body('planName').exists()).notEmpty(),
-  check('colorchip').if(body('colorchip').exists()).notEmpty(),
-  check('planDate').if(body('planDate').exists()).notEmpty(),
-  check('isCompleted').if(body('isCompleted').exists()).notEmpty(),
-];
-export { errorValidator, getPlanValidation, updatePlanValidation };
+// export const updatePlanValidation = [
+//   check('planName').if(body('planName').exists()).notEmpty(),
+//   check('colorchip').if(body('colorchip').exists()).notEmpty(),
+//   check('planDate').if(body('planDate').exists()).notEmpty(),
+//   check('isCompleted').if(body('isCompleted').exists()).notEmpty(),
+// ];
+
+// export const createPlanValidation = [
+//   body('planName').notEmpty(),
+//   body('planDate').notEmpty(),
+//   body('type').notEmpty(),
+// ];

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -8,6 +8,7 @@ const message = {
 
   //계획 블록
   READ_PLAN_SUCCESS: '계획블록 조회 성공',
+  CREATE_PLAN_SUCCESS: '계획블록 생성 성공',
 };
 
 export default message;

--- a/src/services/PlanService.ts
+++ b/src/services/PlanService.ts
@@ -1,7 +1,9 @@
+import { PlanOrder } from './../entities/PlanOrder';
 import { PlanOrderRepository } from './../repositories/PlanOrderRepository';
 import { Service } from 'typedi';
 import { InjectRepository } from 'typeorm-typedi-extensions';
 import { PlanRepository } from '../repositories/PlanRepository';
+import dayjs from 'dayjs';
 
 @Service()
 export class DailyPlanService {
@@ -38,6 +40,153 @@ export class DailyPlanService {
         case 'routine': {
           const plans = await this.planRepository.findByIds(totalPlanList);
           return plans;
+        }
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  public async createPlan(
+    userId: number,
+    planName: string,
+    date: Date,
+    type: string,
+  ) {
+    try {
+      switch (type) {
+        case 'daily': {
+          let existPlanOrder;
+
+          //* 계획하는 날짜에 planOrder가 있는지 확인
+          existPlanOrder = await this.planOrderRepository.find({
+            where: {
+              user_id: userId,
+              type: type,
+              planDate: date,
+            },
+          });
+
+          if (existPlanOrder.length == 0) {
+            //* planOrder가 없다면 그 날의 daily, reschedule planOrder 생성
+            const dailyplanOrder = this.planOrderRepository.create({
+              user_id: userId,
+              type: type,
+              planDate: date,
+              planList: [],
+            });
+            existPlanOrder = [
+              await this.planOrderRepository.save(dailyplanOrder),
+            ];
+
+            const reschedulePlanOrder = this.planOrderRepository.create({
+              user_id: userId,
+              type: 'reschedule',
+              planDate: date,
+              planList: [],
+            });
+            await this.planOrderRepository.save(reschedulePlanOrder);
+          }
+
+          //* Plan 테이블에 계획 블록 생성
+          const planData = this.planRepository.create({
+            planName: planName,
+            planDate: date,
+            user: {
+              id: userId,
+            },
+            colorchip: 'white',
+          });
+          const createPlan = await this.planRepository.save(planData);
+
+          //* planOrder에 planId 저장
+          let planList = existPlanOrder.pop()?.planList as number[];
+          planList.push(createPlan.id);
+
+          //* planOrder를 DB에 업데이트
+          await this.planOrderRepository.update(
+            {
+              user_id: userId,
+              type: type,
+              planDate: date,
+            },
+            {
+              planList: planList,
+            },
+          );
+
+          //* response 반환
+          const data = {
+            id: createPlan.id,
+            planDate: dayjs(createPlan.planDate).format('YYYY-MM-DD'),
+            planName: createPlan.planName,
+            colorchip: createPlan.colorchip,
+            planTime: createPlan.planTime,
+            fulfilTime: createPlan.fulfillTime,
+            type: type,
+            createdAt: createPlan.createdAt,
+          };
+          return data;
+        }
+        case 'routine': {
+          let existPlanOrder;
+
+          //* 계획하는 날짜에 planOrder가 있는지 확인
+          existPlanOrder = await this.planOrderRepository.find({
+            where: {
+              user_id: userId,
+              type: type,
+              planDate: date,
+            },
+          });
+          if (!existPlanOrder) {
+            //* planOrder가 없다면 그 날의 routine planOrder 생성
+            existPlanOrder = [
+              this.planOrderRepository.create({
+                user_id: userId,
+                type: type,
+                planDate: date,
+              }),
+            ];
+          }
+
+          //* Plan 테이블에 계획 블록 생성
+          const planData = await this.planRepository.create({
+            planName: planName,
+            planDate: date,
+            user: {
+              id: userId,
+            },
+            colorchip: 'white',
+          });
+          const createPlan = await this.planRepository.save(planData);
+
+          //* planOrder에 planId 저장
+          let planList = existPlanOrder.pop()?.planList as number[];
+          planList.push(createPlan.id);
+
+          //* planOrder를 DB에 업데이트
+          await this.planOrderRepository.update(
+            {
+              user_id: userId,
+              type: type,
+              planDate: date,
+            },
+            {
+              planList: planList,
+            },
+          );
+          const data = {
+            id: createPlan.id,
+            planDate: dayjs(createPlan.planDate).format('YYYY-MM-DD'),
+            planName: createPlan.planName,
+            colorchip: createPlan.colorchip,
+            planTime: createPlan.planTime,
+            fulfilTime: createPlan.fulfillTime,
+            type: type,
+            createdAt: createPlan.createdAt,
+          };
+          return data;
         }
       }
     } catch (error) {

--- a/src/services/PlanService.ts
+++ b/src/services/PlanService.ts
@@ -139,14 +139,16 @@ export class DailyPlanService {
               planDate: date,
             },
           });
-          if (!existPlanOrder) {
+          if (existPlanOrder.length == 0) {
             //* planOrder가 없다면 그 날의 routine planOrder 생성
+            const routinePlanOrder = this.planOrderRepository.create({
+              user_id: userId,
+              type: type,
+              planDate: date,
+              planList: [],
+            });
             existPlanOrder = [
-              this.planOrderRepository.create({
-                user_id: userId,
-                type: type,
-                planDate: date,
-              }),
+              await this.planOrderRepository.save(routinePlanOrder),
             ];
           }
 
@@ -159,11 +161,11 @@ export class DailyPlanService {
             },
             colorchip: 'white',
           });
-          const createPlan = await this.planRepository.save(planData);
+          const routinePlan = await this.planRepository.save(planData);
 
           //* planOrder에 planId 저장
           let planList = existPlanOrder.pop()?.planList as number[];
-          planList.push(createPlan.id);
+          planList.push(routinePlan.id);
 
           //* planOrder를 DB에 업데이트
           await this.planOrderRepository.update(
@@ -177,14 +179,14 @@ export class DailyPlanService {
             },
           );
           const data = {
-            id: createPlan.id,
-            planDate: dayjs(createPlan.planDate).format('YYYY-MM-DD'),
-            planName: createPlan.planName,
-            colorchip: createPlan.colorchip,
-            planTime: createPlan.planTime,
-            fulfilTime: createPlan.fulfillTime,
+            id: routinePlan.id,
+            planDate: dayjs(routinePlan.planDate).format('YYYY-MM-DD'),
+            planName: routinePlan.planName,
+            colorchip: routinePlan.colorchip,
+            planTime: routinePlan.planTime,
+            fulfilTime: routinePlan.fulfillTime,
             type: type,
-            createdAt: createPlan.createdAt,
+            createdAt: routinePlan.createdAt,
           };
           return data;
         }

--- a/src/services/PlanService.ts
+++ b/src/services/PlanService.ts
@@ -1,9 +1,7 @@
-import { PlanOrder } from './../entities/PlanOrder';
 import { PlanOrderRepository } from './../repositories/PlanOrderRepository';
 import { Service } from 'typedi';
 import { InjectRepository } from 'typeorm-typedi-extensions';
 import { PlanRepository } from '../repositories/PlanRepository';
-import dayjs from 'dayjs';
 
 @Service()
 export class PlanService {
@@ -202,7 +200,7 @@ export class PlanService {
   public async createPlan(
     userId: number,
     planName: string,
-    date: Date,
+    planDate: string,
     type: string,
   ) {
     try {
@@ -215,7 +213,7 @@ export class PlanService {
             where: {
               user_id: userId,
               type: type,
-              planDate: date,
+              planDate,
             },
           });
 
@@ -224,7 +222,7 @@ export class PlanService {
             const dailyplanOrder = this.planOrderRepository.create({
               user_id: userId,
               type: type,
-              planDate: date,
+              planDate,
               planList: [],
             });
             existPlanOrder = [
@@ -234,7 +232,7 @@ export class PlanService {
             const reschedulePlanOrder = this.planOrderRepository.create({
               user_id: userId,
               type: 'reschedule',
-              planDate: date,
+              planDate,
               planList: [],
             });
             await this.planOrderRepository.save(reschedulePlanOrder);
@@ -243,7 +241,7 @@ export class PlanService {
           //* Plan 테이블에 계획 블록 생성
           const planData = this.planRepository.create({
             planName: planName,
-            planDate: date,
+            planDate,
             user: {
               id: userId,
             },
@@ -260,7 +258,7 @@ export class PlanService {
             {
               user_id: userId,
               type: type,
-              planDate: date,
+              planDate,
             },
             {
               planList: planList,
@@ -270,12 +268,13 @@ export class PlanService {
           //* response 반환
           const data = {
             id: createPlan.id,
-            planDate: dayjs(createPlan.planDate).format('YYYY-MM-DD'),
+            planDate: createPlan.planDate,
             planName: createPlan.planName,
             colorchip: createPlan.colorchip,
             planTime: createPlan.planTime,
             fulfilTime: createPlan.fulfillTime,
             type: type,
+            isCompleted: createPlan.isCompleted,
             createdAt: createPlan.createdAt,
           };
           return data;
@@ -288,15 +287,13 @@ export class PlanService {
             where: {
               user_id: userId,
               type: type,
-              planDate: date,
             },
           });
           if (existPlanOrder.length == 0) {
-            //* planOrder가 없다면 그 날의 routine planOrder 생성
+            //* planOrder가 없다면 routine planOrder 생성
             const routinePlanOrder = this.planOrderRepository.create({
               user_id: userId,
               type: type,
-              planDate: date,
               planList: [],
             });
             existPlanOrder = [
@@ -306,8 +303,7 @@ export class PlanService {
 
           //* Plan 테이블에 계획 블록 생성
           const planData = await this.planRepository.create({
-            planName: planName,
-            planDate: date,
+            planName,
             user: {
               id: userId,
             },
@@ -323,21 +319,21 @@ export class PlanService {
           await this.planOrderRepository.update(
             {
               user_id: userId,
-              type: type,
-              planDate: date,
+              type,
             },
             {
-              planList: planList,
+              planList,
             },
           );
           const data = {
             id: routinePlan.id,
-            planDate: dayjs(routinePlan.planDate).format('YYYY-MM-DD'),
+            planDate: routinePlan.planDate,
             planName: routinePlan.planName,
             colorchip: routinePlan.colorchip,
             planTime: routinePlan.planTime,
             fulfilTime: routinePlan.fulfillTime,
             type: type,
+            isCompleted: routinePlan.isCompleted,
             createdAt: routinePlan.createdAt,
           };
           return data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,6 +716,11 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"


### PR DESCRIPTION
<!-- 
- PR 제목: [feat/fix/refactor...] 작업 내용 한 줄 요약 (브랜치 이름)
- commit message가 적절한지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer로 등록해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다. 
-->


## 📝 PR 요약

<!--
해당 pr에서 작업한 내역을 적어주세요.
-->

- 일간, 루틴로드 계획 블록을 생성합니다.

<br/>

## 📌 변경 사항 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->
- ~dayjs를 추가하였습니다. 나중에 pull 받고 yarn 실행해주세요!~
- 조회랑 생성에서 보내주는 planDate를 보내주는 타입이 다른거 같아서 이 부분을 서팟과 논의해보고 싶습니다. 계속 고민이 되네요!
- 하루 계획 블록을 처음 생성할 때, 그날의 planOrder도 생성해주어야 할 것 같아서 그 부분까지 고려해서 구현해보았습니다.
- 잘 짜보겠다고 짜긴 했는데.. 제법 복잡하게 되었네요.. 제가 생각한 로직 구현에 대한 방향은 주석을 달아놓았으니, 참고해주시면 될 것 같습니다!


![image](https://user-images.githubusercontent.com/82744423/213991835-e6c2b366-2c6d-4d70-a131-500667212fe4.png)

<br/>

## 🔗 Linked Issue
close #22 
