### PR TITLE
fix: 계획 블록 생성 로직 수정

### DIFF
--- a/src/config/RoutingConfig.ts
+++ b/src/config/RoutingConfig.ts
@@ -2,4 +2,5 @@ export const routingControllerOptions = {
   routePrefix: '/api',
   controllers: [`${__dirname}/../controllers/*{.ts,.js}`],
   middlewares: [`${__dirname}/../middleware/*{.ts,.js}`],
+  defaultErrorHandler: false,
 };

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -1,3 +1,4 @@
+import { PlanService } from './../services/PlanService';
 import {
   BodyParam,
   Get,
@@ -24,6 +25,7 @@ export class AuthController {
   constructor(
     private userService: UserService,
     private authService: AuthService,
+    private planService: PlanService,
   ) {}
 
   @HttpCode(200)
@@ -81,6 +83,11 @@ export class AuthController {
           accessToken: accessToken,
           refreshToken: refreshToken,
         };
+
+        //* 회원 가입 시, 서비스에서 활용할 우회할 계획 순서배열 & 루틴로드 순서배열 생성
+        await this.planService.createInitReschedulePlanOrder(newUser.id);
+        await this.planService.createInitRoutineRoadPlanOrder(newUser.id);
+
         return res
           .status(statusCode.OK)
           .send(success(statusCode.OK, message.SIGNUP_SUCCESS, data));

--- a/src/middleware/errorGenerator.ts
+++ b/src/middleware/errorGenerator.ts
@@ -1,0 +1,33 @@
+import responseMessage from '../modules/responseMessage';
+
+type statusMessage = {
+  [key: number]: string;
+};
+
+const HTTP_STATUS_MESSAGES: statusMessage = {
+  400: responseMessage.BAD_REQUEST,
+  404: responseMessage.NOT_FOUND,
+  500: responseMessage.INTERNAL_SERVER_ERROR,
+};
+
+// interface 이용해 Error 객체에 statusCode key 추가
+export interface ErrorWithStatusCode extends Error {
+  statusCode?: number;
+}
+
+const errorGenerator = ({
+  msg = responseMessage.INTERNAL_SERVER_ERROR,
+  statusCode = 500,
+}: {
+  msg?: string;
+  statusCode: number;
+}): void => {
+  // 인자로 들어오는 메세지와 상태 코드를 매핑
+  const err: ErrorWithStatusCode = new Error(
+    msg || HTTP_STATUS_MESSAGES[statusCode],
+  );
+  err.statusCode = statusCode;
+  throw err;
+};
+
+export default errorGenerator;

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,0 +1,44 @@
+import { ErrorRequestHandler, NextFunction, Request, Response } from 'express';
+import {
+  ExpressErrorMiddlewareInterface,
+  Middleware,
+} from 'routing-controllers';
+import responseMessage from '../modules/responseMessage';
+import { fail } from '../modules/util';
+import { ErrorWithStatusCode } from './errorGenerator';
+
+// const generalErrorHandler: ErrorRequestHandler = (
+//   error: ErrorWithStatusCode,
+//   req: Request,
+//   res: Response,
+//   next: NextFunction,
+// ): void | Response => {
+//   const { message, statusCode } = error;
+//   // 인자로 statusCode를 넘기지 않는 경우, 500 에러를 보냄
+//   if (!statusCode || statusCode == 500) {
+//     return res
+//       .status(500)
+//       .send(fail(500, responseMessage.INTERNAL_SERVER_ERROR));
+//   } else {
+//     return res.status(statusCode).send(fail(statusCode, message));
+//   }
+// };
+
+@Middleware({ type: 'after' })
+export class globalErrorHandler implements ExpressErrorMiddlewareInterface {
+  error(
+    error: ErrorWithStatusCode,
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) {
+    const { message, statusCode } = error;
+    if (!statusCode || statusCode == 500) {
+      return res
+        .status(500)
+        .send(fail(500, responseMessage.INTERNAL_SERVER_ERROR));
+    } else {
+      return res.status(statusCode).send(fail(statusCode, message));
+    }
+  }
+}

--- a/src/services/PlanService.ts
+++ b/src/services/PlanService.ts
@@ -209,7 +209,7 @@ export class PlanService {
         case 'daily': {
           let existPlanOrder;
 
-          //* 계획하는 날짜에 planOrder가 있는지 확인
+          //* 계획하는 날짜에 daily planOrder가 있는지 확인
           existPlanOrder = await this.planOrderRepository.find({
             where: {
               user_id: userId,
@@ -218,35 +218,16 @@ export class PlanService {
             },
           });
 
-          //* 우회할 계획 순서 배열이 있는지 확인
-          const existReschedulePlanOrder =
-            await this.planOrderRepository.findOne({
-              where: {
-                user_id: userId,
-                type: 'reschedule',
-              },
-            });
-
-          //* planOrder가 없다면 reschedule planOrder 생성
-          if (!existReschedulePlanOrder) {
-            const reschedulePlanOrder = this.planOrderRepository.create({
-              user_id: userId,
-              type: 'reschedule',
-              planList: [],
-            });
-            await this.planOrderRepository.insert(reschedulePlanOrder);
-          }
-
           if (existPlanOrder.length == 0) {
             //* planOrder가 없다면 그 날의 daily planOrder 생성
-            const dailyplanOrder = this.planOrderRepository.create({
+            const dailyPlanOrder = this.planOrderRepository.create({
               user_id: userId,
               type: type,
               planDate,
               planList: [],
             });
             existPlanOrder = [
-              await this.planOrderRepository.save(dailyplanOrder),
+              await this.planOrderRepository.save(dailyPlanOrder),
             ];
           }
 
@@ -294,24 +275,13 @@ export class PlanService {
         case 'routine': {
           let existPlanOrder;
 
-          //* 계획하는 날짜에 planOrder가 있는지 확인
+          //* planOrder 탐색
           existPlanOrder = await this.planOrderRepository.find({
             where: {
               user_id: userId,
               type: type,
             },
           });
-          if (existPlanOrder.length == 0) {
-            //* planOrder가 없다면 routine planOrder 생성
-            const routinePlanOrder = this.planOrderRepository.create({
-              user_id: userId,
-              type: type,
-              planList: [],
-            });
-            existPlanOrder = [
-              await this.planOrderRepository.save(routinePlanOrder),
-            ];
-          }
 
           //* Plan 테이블에 계획 블록 생성
           const planData = await this.planRepository.create({
@@ -355,6 +325,25 @@ export class PlanService {
       throw error;
     }
   }
+
+  public async createInitReschedulePlanOrder(userId: number) {
+    const reschedulePlanOrder = this.planOrderRepository.create({
+      user_id: userId,
+      type: 'reschedule',
+      planList: [],
+    });
+    await this.planOrderRepository.insert(reschedulePlanOrder);
+  }
+
+  public async createInitRoutineRoadPlanOrder(userId: number) {
+    const routinePlanOrder = this.planOrderRepository.create({
+      user_id: userId,
+      type: 'routine',
+      planList: [],
+    });
+    await this.planOrderRepository.insert(routinePlanOrder);
+  }
+
   public async deletePlans(
     userId: number,
     planId: number,

--- a/src/services/PlanService.ts
+++ b/src/services/PlanService.ts
@@ -232,7 +232,6 @@ export class PlanService {
             const reschedulePlanOrder = this.planOrderRepository.create({
               user_id: userId,
               type: 'reschedule',
-              planDate,
               planList: [],
             });
             await this.planOrderRepository.insert(reschedulePlanOrder);

--- a/src/services/PlanService.ts
+++ b/src/services/PlanService.ts
@@ -218,8 +218,28 @@ export class PlanService {
             },
           });
 
+          //* 우회할 계획 순서 배열이 있는지 확인
+          const existReschedulePlanOrder =
+            await this.planOrderRepository.findOne({
+              where: {
+                user_id: userId,
+                type: 'reschedule',
+              },
+            });
+
+          //* planOrder가 없다면 reschedule planOrder 생성
+          if (!existReschedulePlanOrder) {
+            const reschedulePlanOrder = this.planOrderRepository.create({
+              user_id: userId,
+              type: 'reschedule',
+              planDate,
+              planList: [],
+            });
+            await this.planOrderRepository.insert(reschedulePlanOrder);
+          }
+
           if (existPlanOrder.length == 0) {
-            //* planOrder가 없다면 그 날의 daily, reschedule planOrder 생성
+            //* planOrder가 없다면 그 날의 daily planOrder 생성
             const dailyplanOrder = this.planOrderRepository.create({
               user_id: userId,
               type: type,
@@ -229,14 +249,6 @@ export class PlanService {
             existPlanOrder = [
               await this.planOrderRepository.save(dailyplanOrder),
             ];
-
-            const reschedulePlanOrder = this.planOrderRepository.create({
-              user_id: userId,
-              type: 'reschedule',
-              planDate,
-              planList: [],
-            });
-            await this.planOrderRepository.save(reschedulePlanOrder);
           }
 
           //* Plan 테이블에 계획 블록 생성


### PR DESCRIPTION
<!-- 
- PR 제목: [feat/fix/refactor...] 작업 내용 한 줄 요약 (브랜치 이름)
- commit message가 적절한지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer로 등록해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다. 
-->


## 📝 PR 요약

<!--
해당 pr에서 작업한 내역을 적어주세요.
-->

-  계획 블록 생성 로직을 수정합니다.

<br/>

## 📌 변경 사항 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->
- 계획하는 날짜에 일간 계획 블록과 우회할 계획 순서 배열이 있는지 확인합니다.
- 없으면 날짜에 맞는 일간 계획 블록 순서 배열을 생성해주고, 날짜가 없는 우회할 계획 순서 배열을 생성해줍니다.

+++
우회할 계획에 대한 순서 배열과 루틴로드에 대한 순서 배열은 날짜와 상관없이 한 번 생성하게 되면 쭉 서비스에서 유지되어야 합니다.
이 로직을 원래 계획블록 생성 API를 호출할 때마다 확인하는 과정을 거쳤는데, 이렇게 된다면 필요없는 쿼리가 두번씩 동작하게 되어 서버가 무척이나 느려지게 됩니다. 그래서 회원가입 시에 우회할 계획과 루틴로드에 대한 순서 배열을 생성해주는 것으로 로직을 수정하도록 하였습니다!

<br/>

## 🔗 Linked Issue
close #36 
