### PR TITLE
fix: 계획블록 조회 반환 값 수정

### DIFF
--- a/src/controllers/TimeBlockController.ts
+++ b/src/controllers/TimeBlockController.ts
@@ -29,33 +29,6 @@ export class TimeBlockController {
   constructor(private timeBlockService: TimeBlockService) {}
 
   @HttpCode(200)
-  @Get('/')
-  @UseBefore(auth, ...getTimeBlockValidation, errorValidator)
-  @UseAfter(generalErrorHandler)
-  @OpenAPI({
-    summary: '타임블록 조회',
-    description: '해당 유저, 해당 날짜의 타임블록 조회',
-    statusCode: '200',
-  })
-  public async fetchData(
-    @Res() res: Response,
-    @QueryParam('planDate') planDate: string,
-  ): Promise<Response> {
-    try {
-      const userId = res.locals.JwtPayload;
-      const data = await this.timeBlockService.fetchPlanTimeBlock(
-        userId,
-        planDate,
-      );
-      return res
-        .status(statusCode.OK)
-        .send(success(statusCode.OK, message.FETCH_TIMEBLOCK_SUCCESS, data));
-    } catch (error) {
-      throw error;
-    }
-  }
-
-  @HttpCode(200)
   @Post('/:planId')
   @UseBefore(auth, ...setTimeBlockValidation, errorValidator)
   @UseAfter(generalErrorHandler)

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -34,7 +34,6 @@ const message = {
   NO_DAILYNOTE: '해당 날짜의 데일리노트가 없습니다.',
 
   //타임 블록
-  FETCH_TIMEBLOCK_SUCCESS: '타임블록 조회 성공',
   UPDATE_TIMEBLOCK_SUCCESS: '타임블록 업데이트 성공',
 };
 

--- a/src/services/PlanService.ts
+++ b/src/services/PlanService.ts
@@ -41,6 +41,8 @@ export class PlanService {
               planName: data.planName,
               colorChip: data.colorchip,
               isCompleted: data.isCompleted,
+              planTime: data.planTime,
+              fulfillTime: data.fulfillTime,
               createdAt: data.createdAt,
             };
             return result;

--- a/src/services/TimeBlockService.ts
+++ b/src/services/TimeBlockService.ts
@@ -11,27 +11,6 @@ import statusCode from '../modules/statusCode';
 export class TimeBlockService {
   constructor(@InjectRepository() private planRepository: PlanRepository) {}
 
-  public async fetchPlanTimeBlock(userId: number, planDate: string) {
-    try {
-      const plans = await this.planRepository.find({
-        where: {
-          planDate,
-          user: {
-            id: userId,
-          },
-        },
-      });
-
-      const response = new DateTimeBlockDto();
-      response.planDate = planDate;
-      response.plans = this.planToDto(plans);
-
-      return response;
-    } catch (error) {
-      throw error;
-    }
-  }
-
   public async setTimeBlock(
     userId: number,
     planId: number,
@@ -169,19 +148,5 @@ export class TimeBlockService {
     } catch (error) {
       throw error;
     }
-  }
-
-  private planToDto(plans: Plan[]): TimeBlockDto[] {
-    const timeBlockList = plans.map((plan) => {
-      const timeBlock = new TimeBlockDto();
-
-      timeBlock.planId = plan.id;
-      timeBlock.planTime = plan.planTime;
-      timeBlock.fulfillTime = plan.fulfillTime;
-
-      return timeBlock;
-    });
-
-    return timeBlockList;
   }
 }


### PR DESCRIPTION
<!-- 
- PR 제목: [feat/fix/refactor...] 작업 내용 한 줄 요약 (브랜치 이름)
- commit message가 적절한지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer로 등록해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다. 
-->


## 📝 PR 요약

<!--
해당 pr에서 작업한 내역을 적어주세요.
-->

- 타임블록 조회 API를 삭제하였습니다.
- 계획블록 조회 API 호출 시, planTime과 fulfilTime이 같이 반환되는 로직으로 변경하였습니다.

<br/>

## 📌 변경 사항 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->
- timeBlockController에서 타임블록 조회하는 로직 함수 삭제
- timeBlockService에서 타임블록 조회하는 로직 함수 삭제
- responseMessage에서 타임블록 조회 성공 메시지 삭제
- planService에서 계획블록 조회 시 planTime, fulfillTime 반환 값 추가
<br/>

## 🔗 Linked Issue
close #42 
