### PR TITLE
fix: 데일리 노트 생성 시, emoji, feel, memo에 대한 null 값 허용

### DIFF
--- a/src/entities/DailyNote.ts
+++ b/src/entities/DailyNote.ts
@@ -16,13 +16,13 @@ export class DailyNote {
   @Column({ name: 'plan_date', nullable: true })
   planDate?: string;
 
-  @Column()
+  @Column({ nullable: true })
   emoji?: string;
 
-  @Column()
+  @Column({ nullable: true })
   feel?: string;
 
-  @Column()
+  @Column({ nullable: true })
   memo?: string;
 
   @ManyToOne(() => User, (user) => user.dailynotes)


### PR DESCRIPTION
<!-- 
- PR 제목: [feat/fix/refactor...] 작업 내용 한 줄 요약 (브랜치 이름)
- commit message가 적절한지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer로 등록해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다. 
-->


## 📝 PR 요약

<!--
해당 pr에서 작업한 내역을 적어주세요.
-->

- 데일리 노트 생성할 때, 이모지와 feel, memo에 대한 데이터가 들어오지 않을 경우에 대한 처리를 해줍니다.

<br/>

## 📌 변경 사항 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->
- DailyNote entity에서 emoji, feel, memo에 대한 컬럼 옵션에 nullable을 true로 설정해주었습니다! 

<br/>

## 🔗 Linked Issue
close #48 
